### PR TITLE
Add 'B' emoji replacement, abstract into replacer

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -16,7 +16,10 @@ client.on('message', (message) => {
       mock(message, args)
       break
     case 'clap':
-      clap(message, args)
+      replacer(message, args, ' ', '👏', true)
+      break
+    case 'b':
+      replacer(message, args, 'b', '🅱')
       break
     default:
   }
@@ -52,7 +55,7 @@ function mock(message, args) {
     })
 }
 
-function clap(message, args) {
+function replacer(message, args, from, to, caps = false) {
   message.channel.fetchMessages()
     .then(messages => {
       let filteredMessages
@@ -66,12 +69,12 @@ function clap(message, args) {
       const lastMessage = filteredMessages.first()
       const newMessageParts = []
       for (let i = 0; i < lastMessage.content.length; i++) {
-        if (lastMessage.content[i] === ' ') {
-          newMessageParts.push('👏')
+        if (lastMessage.content[i].toLowerCase() === from) {
+          newMessageParts.push(to)
           continue
         }
 
-        newMessageParts.push(lastMessage.content[i].toUpperCase())
+        newMessageParts.push(caps ? lastMessage.content[i].toUpperCase() : lastMessage.content[i])
       }
 
       message.channel.send(lastMessage.author + ' ' + newMessageParts.join(''))


### PR DESCRIPTION
Pretty self explanatory. Made clap function into a reusable replacer function, takes in from, to, and caps arguments. Implemented 🅱 command using replacer.